### PR TITLE
Include requirements.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
This would make it possible to install from PyPI tarballs.

I’ll open an alternative PR for your consideration with a more complete manifest that would allow users to build the docs from the tarball, which was my original intention when fetching the tarball.

Should you be amenable to *either* of the changes I’d be willing to do the same for your other packages in the dependency chain, using whichever style you prefer

Thanks,

James
