### PR TITLE
Include all user project files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include LICENSE
+include pytest.ini
+include requirements*.txt
+
+include docs/*.rst
+include docs/conf.py
+include docs/requirements.txt
+
+recursive-include tests *.py


### PR DESCRIPTION
This would make it possible to install the package, run tests and read docs from PyPI tarballs.

As I said in #17, should you be amenable to *either* of the routes I’d be willing to do the same for your other packages in the dependency chain.

Thanks,

James
